### PR TITLE
Make non-matching coordinates more obvious in hinting

### DIFF
--- a/src/enforce_same_position.ts
+++ b/src/enforce_same_position.ts
@@ -4,25 +4,20 @@ import { ArrayNode, NumberNode } from '@humanwhocodes/momoa';
 export function enforceSamePosition(issues: HintIssue[], node: ArrayNode) {
   const first = node.elements[0] as ArrayNode;
   const last = node.elements[node.elements.length - 1] as ArrayNode;
+  const len = Math.max(first.elements.length, last.elements.length);
 
-  if (first.elements.length !== last.elements.length) {
-    issues.push(
-      makeIssue(
-        'First and last positions of a Polygon or MultiPolygon’s ring should be the same.',
-        node
-      )
-    );
-    return;
-  }
-
-  for (let j = 0; j < first.elements.length; j++) {
-    const firstValue = (first.elements[j] as NumberNode).value;
-    const secondValue = (last.elements[j] as NumberNode).value;
+  for (let j = 0; j < len; j++) {
+    const firstValue = (first.elements[j] as NumberNode | undefined)?.value;
+    const secondValue = (last.elements[j] as NumberNode | undefined)?.value;
     if (firstValue !== secondValue) {
       issues.push(
         makeIssue(
           'First and last positions of a Polygon or MultiPolygon’s ring should be the same.',
-          last.elements[j]
+          first
+        ),
+        makeIssue(
+          'First and last positions of a Polygon or MultiPolygon’s ring should be the same.',
+          last
         )
       );
       return;


### PR DESCRIPTION
If you make the first coordinate of a Polygon incorrect, the last coordinate gets an error message - but that coord might be far offscreen. This assigns a lint error to both the first and last coordinate.