### PR TITLE
test: Test for geometrycollection null

### DIFF
--- a/test/bad.test.ts
+++ b/test/bad.test.ts
@@ -48,6 +48,12 @@ describe('check', () => {
     ).toThrow(HintError);
   });
 
+  it('geometry collection with null', () => {
+    expect(() =>
+      check(JSON.stringify({ type: 'GeometryCollection', geometries: [null] }))
+    ).toThrow(HintError);
+  });
+
   it('forbidden properties', () => {
     expect(() =>
       check(


### PR DESCRIPTION
Confirm that this catches GeometryCollections with null items.